### PR TITLE
Remove invalid Discord invite link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Documentation
     url: https://smithery.ai/docs
     about: Check our documentation for help and guides
-  - name: Discord Community
-    url: https://discord.gg/smithery
-    about: Join our Discord for questions and discussions

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ For feature requests, please describe:
 
 - [Smithery Website](https://smithery.ai)
 - [Documentation](https://smithery.ai/docs)
-- [Discord Community](https://discord.gg/smithery)
 
 ## License
 


### PR DESCRIPTION
Remove Discord link from README and issue template config as the invite URL is invalid.